### PR TITLE
fix: use parameters to workaround hf negative prompt bug

### DIFF
--- a/i18n/en-US/_stable-diffusion-generator.json
+++ b/i18n/en-US/_stable-diffusion-generator.json
@@ -1,6 +1,6 @@
 {
   "lazy-mode": "Lazy mode, input your scene",
-  "method-1-chatgpt-generate": "Method 1: ChatGPT generate",
+  "method-1-chatgpt-generate": "Method 1: Ask ChatGPT",
   "method-2-manual-create": "Method 2: Prompt generator",
   "character": "Character",
   "other": "Other",
@@ -8,13 +8,14 @@
   "bracket-style": "Bracket style",
   "round-bracket": "Parentheses",
   "curly-bracket": "Curly brackets",
-  "copy-spell-and-save": "Copy spell and save",
+  "copy-spell-and-save": "Copy prompt and save",
   "clear-cache": "Clear cache",
-  "test-spell-online": "Test spell online",
-  "other-online-spell-tools": "Other online spell tools",
+  "test-spell-online": "Test prompt online",
+  "other-online-spell-tools": "Other online tools",
   "generate": "Generate",
+  "reset": "Reset",
   "import_from_clipboard": "Import from clipboard",
-  "model_503_error_prefix": "Model is rate limited, please retry with same spell after at least ",
+  "model_503_error_prefix": "Model is rate limited, please retry with same prompt after at least ",
   "model_503_error_suffix": " seconds.",
-  "notes-black-image": "Note: Black image means the result is blocked, please try another spell"
+  "notes-black-image": "Note: Black image means the result is blocked, please try another prompt"
 }

--- a/i18n/zh-CN/_stable-diffusion-generator.json
+++ b/i18n/zh-CN/_stable-diffusion-generator.json
@@ -13,6 +13,7 @@
   "test-spell-online": "在线测试咒语",
   "other-online-spell-tools": "其它在线咒语工具",
   "generate": "生成",
+  "reset": "重置",
   "import_from_clipboard": "从剪贴板导入",
   "model_503_error_prefix": "模型限流中，请等待至少 ",
   "model_503_error_suffix": " 秒后使用相同咒语重试",

--- a/src/app/[lang]/stable-diffusion-generator/page.client.tsx
+++ b/src/app/[lang]/stable-diffusion-generator/page.client.tsx
@@ -433,7 +433,8 @@ function StableDiffusionGenerator({ i18n }: GeneralI18nProps) {
   const [isSubmitting] = useState(false);
   const [bracketType, setBracketType] = useState<BracketType>(BracketType.round);
 
-  const DEFAULT_NEGATIVE_PROMPT =  "nsfw, not_safe_for_work, nude, sexual, worst quality, low quality, normal quality, watermark, blurry";
+  const DEFAULT_NEGATIVE_PROMPT =
+    "nsfw, not_safe_for_work, nude, sexual, worst quality, low quality, normal quality, watermark, blurry";
   const [currentPrompt, setCurrentPrompt] = useState<StableDiffusionGenData>({
     prompt: "",
     negativePrompt: DEFAULT_NEGATIVE_PROMPT,
@@ -507,7 +508,7 @@ function StableDiffusionGenerator({ i18n }: GeneralI18nProps) {
 
   const handlePromptReset = (event?: ChangeEvent<HTMLTextAreaElement>) => {
     currentPrompt.negativePrompt = DEFAULT_NEGATIVE_PROMPT;
-    handlePromptGeneratorChange(formik.values, bracketType)
+    handlePromptGeneratorChange(formik.values, bracketType);
   };
 
   return (

--- a/src/components/StableDiffusion/HuggingFaceTxt2Img.tsx
+++ b/src/components/StableDiffusion/HuggingFaceTxt2Img.tsx
@@ -27,22 +27,22 @@ export const HuggingFaceTxt2Img = ({ model, prompt, dict }: HuggingFaceComponent
       inputs: prompt.prompt,
       parameters: {
         negative_prompt: [prompt.negativePrompt],
-        num_images_per_prompt: 1
+        num_images_per_prompt: 1,
       },
-      options: {}
+      options: {},
     };
     if (wait_for_model)
       payload.options = {
-        wait_for_model: true
-      }
+        wait_for_model: true,
+      };
     return fetch("https://api-inference.huggingface.co/models/" + model, {
       method: "POST",
       cache: "no-cache",
       headers: {
         "Content-Type": "application/json",
-        "Authorization": "Bearer " + process.env.NEXT_PUBLIC_HUGGING_FACE_ACCESS_TOKEN,
+        Authorization: "Bearer " + process.env.NEXT_PUBLIC_HUGGING_FACE_ACCESS_TOKEN,
       },
-      body: JSON.stringify(payload)
+      body: JSON.stringify(payload),
     });
   };
 
@@ -86,7 +86,13 @@ export const HuggingFaceTxt2Img = ({ model, prompt, dict }: HuggingFaceComponent
     <SimpleGrid gap={3} p={3} columns={1} border='1px solid lightgrey'>
       <Grid>
         <Flex alignItems='center'>
-          <Image alt="Hugging Face" src="https://huggingface.co/front/assets/huggingface_logo-noborder.svg" width={20} height={20} /> &nbsp;Hugging Face
+          <Image
+            alt='Hugging Face'
+            src='https://huggingface.co/front/assets/huggingface_logo-noborder.svg'
+            width={20}
+            height={20}
+          />{" "}
+          &nbsp;Hugging Face
         </Flex>
         <Link mt={1} href={"https://huggingface.co/" + model} isExternal>
           {model}

--- a/src/components/StableDiffusion/HuggingFaceTxt2Img.tsx
+++ b/src/components/StableDiffusion/HuggingFaceTxt2Img.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { Button, Grid, Link, SimpleGrid, Text } from "@chakra-ui/react";
+import { Button, Flex, Grid, Link, SimpleGrid, Text } from "@chakra-ui/react";
 import Image from "next/image";
 import styled from "@emotion/styled";
 import { StableDiffusionDataToString } from "@/data-processor/SduiParser";
@@ -10,6 +10,7 @@ import { StableDiffusionGenData } from "@/data-processor/StableDiffusionGenData"
 const ImageNote = styled("div")`
   font-size: 0.8rem;
   color: #888;
+  width: 256px;
 `;
 
 type HuggingFaceComponentProps = { model: string; prompt: StableDiffusionGenData; dict: Record<string, string> };
@@ -21,7 +22,31 @@ export const HuggingFaceTxt2Img = ({ model, prompt, dict }: HuggingFaceComponent
     prompt: StableDiffusionDataToString(prompt),
   });
 
-  const callHuggingFace = async () => {
+  const callHuggingFace = async (wait_for_model?: boolean) => {
+    const payload = {
+      inputs: prompt.prompt,
+      parameters: {
+        negative_prompt: [prompt.negativePrompt],
+        num_images_per_prompt: 1
+      },
+      options: {}
+    };
+    if (wait_for_model)
+      payload.options = {
+        wait_for_model: true
+      }
+    return fetch("https://api-inference.huggingface.co/models/" + model, {
+      method: "POST",
+      cache: "no-cache",
+      headers: {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer " + process.env.NEXT_PUBLIC_HUGGING_FACE_ACCESS_TOKEN,
+      },
+      body: JSON.stringify(payload)
+    });
+  };
+
+  const handleOnGenerate = async () => {
     if (!prompt) return;
     if (!prompt.prompt) return;
     setHuggingFace({
@@ -30,18 +55,10 @@ export const HuggingFaceTxt2Img = ({ model, prompt, dict }: HuggingFaceComponent
       error: "",
       prompt: StableDiffusionDataToString(prompt),
     });
-    const response = await fetch("https://api-inference.huggingface.co/models/" + model, {
-      method: "POST",
-      cache: "no-cache",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: "Bearer " + process.env.NEXT_PUBLIC_HUGGING_FACE_ACCESS_TOKEN,
-      },
-      body: JSON.stringify({
-        inputs: prompt.prompt,
-        negative_prompt: prompt.negativePrompt,
-      }),
-    });
+    let response = await callHuggingFace();
+    if (response.status == 503) {
+      response = await callHuggingFace(true);
+    }
     if (response.status == 200) {
       const imgBlob = await response.blob();
       const objectURL = URL.createObjectURL(imgBlob);
@@ -66,16 +83,19 @@ export const HuggingFaceTxt2Img = ({ model, prompt, dict }: HuggingFaceComponent
   };
 
   return (
-    <SimpleGrid gap={3} p={3} columns={1}>
+    <SimpleGrid gap={3} p={3} columns={1} border='1px solid lightgrey'>
       <Grid>
-        <Link href={"https://huggingface.co/" + model} isExternal>
+        <Flex alignItems='center'>
+          <Image alt="Hugging Face" src="https://huggingface.co/front/assets/huggingface_logo-noborder.svg" width={20} height={20} /> &nbsp;Hugging Face
+        </Flex>
+        <Link mt={1} href={"https://huggingface.co/" + model} isExternal>
           {model}
         </Link>
         <Button
-          mt={4}
+          mt={2}
           colorScheme='teal'
           isLoading={huggingFace && huggingFace.loading}
-          onClick={() => callHuggingFace()}
+          onClick={() => handleOnGenerate()}
         >
           {dict["generate"]}
         </Button>
@@ -83,7 +103,7 @@ export const HuggingFaceTxt2Img = ({ model, prompt, dict }: HuggingFaceComponent
       <Grid>
         <ImageNote>{dict["notes-black-image"]}</ImageNote>
         {huggingFace && huggingFace.image && (
-          <Image alt={huggingFace.prompt} src={huggingFace.image} width={512} height={512} />
+          <Image alt={huggingFace.prompt} src={huggingFace.image} width={256} height={256} />
         )}
         {huggingFace && huggingFace.error && <Text>{huggingFace.error}</Text>}
       </Grid>

--- a/src/components/StableDiffusion/SdPrompt.tsx
+++ b/src/components/StableDiffusion/SdPrompt.tsx
@@ -61,23 +61,33 @@ export function SdPrompt({ prompt, readonly = false, dict = {}, onChange, onRese
         resize='none'
         onChange={handleOnChange}
       ></StyledGreyTextarea>
-      {readonly && <Grid pt={2}>
-        <Text>Model: {prompt.model}</Text>
-        {prompt.lora && prompt.lora.length > 0 && <Text>LoRA: {prompt.lora.join(", ")} </Text>}
-        <Text>Sampler: {prompt.sampler}</Text>
-        <Text>CFG Scale: {prompt.cfgScale}</Text>
-        <Text>Steps: {prompt.steps}</Text>
-        <Text>Seed: {prompt.seed}</Text>
-      </Grid>}
+      {readonly && (
+        <Grid pt={2}>
+          <Text>Model: {prompt.model}</Text>
+          {prompt.lora && prompt.lora.length > 0 && <Text>LoRA: {prompt.lora.join(", ")} </Text>}
+          <Text>Sampler: {prompt.sampler}</Text>
+          <Text>CFG Scale: {prompt.cfgScale}</Text>
+          <Text>Steps: {prompt.steps}</Text>
+          <Text>Seed: {prompt.seed}</Text>
+        </Grid>
+      )}
       <Flex pt={5} marginLeft='auto'>
-        {!readonly && <Box>
-          <Button variant='solid' marginRight={2} onClick={(event) => handleOnLoadFromClipboard(event)}>
-            {dict["import_from_clipboard"]}
-          </Button>
-          <Button variant='solid' marginRight={2} onClick={(event) => { if (onReset) onReset(event); }}>
-            {dict["reset"]}
-          </Button>
-        </Box>}
+        {!readonly && (
+          <Box>
+            <Button variant='solid' marginRight={2} onClick={(event) => handleOnLoadFromClipboard(event)}>
+              {dict["import_from_clipboard"]}
+            </Button>
+            <Button
+              variant='solid'
+              marginRight={2}
+              onClick={(event) => {
+                if (onReset) onReset(event);
+              }}
+            >
+              {dict["reset"]}
+            </Button>
+          </Box>
+        )}
         <Button variant='solid' colorScheme='teal'>
           <CopyComponent value={StableDiffusionDataToString(prompt)} />
         </Button>

--- a/src/components/StableDiffusion/SdPrompt.tsx
+++ b/src/components/StableDiffusion/SdPrompt.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useRef, useEffect, ChangeEvent, MouseEvent } from "react";
-import { Button, Grid, Text, Textarea } from "@chakra-ui/react";
+import { Box, Button, Flex, Grid, Text, Textarea } from "@chakra-ui/react";
 import CopyComponent from "@/components/CopyComponent";
 import { StableDiffusionGenData } from "@/data-processor/StableDiffusionGenData";
 import { parseStableDiffusionData, StableDiffusionDataToString } from "@/data-processor/SduiParser";
@@ -13,13 +13,15 @@ const StyledGreyTextarea = styled(Textarea)`
 `;
 
 type PromptChangeHandler = (event?: any, prompt?: StableDiffusionGenData) => void;
+type PromptResetHandler = (event?: any) => void;
 type SdPromptComponentProps = {
   prompt: StableDiffusionGenData;
   readonly?: boolean;
   dict?: Record<string, string>;
   onChange?: PromptChangeHandler;
+  onReset?: PromptResetHandler;
 };
-export function SdPrompt({ prompt, readonly = false, dict = {}, onChange }: SdPromptComponentProps) {
+export function SdPrompt({ prompt, readonly = false, dict = {}, onChange, onReset }: SdPromptComponentProps) {
   const promptRef = useRef<HTMLTextAreaElement | null>(null);
   const negativePromptRef = useRef<HTMLTextAreaElement | null>(null);
 
@@ -59,25 +61,27 @@ export function SdPrompt({ prompt, readonly = false, dict = {}, onChange }: SdPr
         resize='none'
         onChange={handleOnChange}
       ></StyledGreyTextarea>
-      {readonly ? (
-        <Grid pt={2}>
-          <Text>Model: {prompt.model}</Text>
-          {prompt.lora && prompt.lora.length > 0 && <Text>LoRA: {prompt.lora.join(", ")} </Text>}
-          <Text>Sampler: {prompt.sampler}</Text>
-          <Text>CFG Scale: {prompt.cfgScale}</Text>
-          <Text>Steps: {prompt.steps}</Text>
-          <Text>Seed: {prompt.seed}</Text>
-          <Button variant='solid' colorScheme='teal' marginLeft='auto'>
-            <CopyComponent value={StableDiffusionDataToString(prompt)} />
-          </Button>
-        </Grid>
-      ) : (
-        <Grid pt={5}>
-          <Button variant='solid' colorScheme='teal' onClick={(event) => handleOnLoadFromClipboard(event)}>
+      {readonly && <Grid pt={2}>
+        <Text>Model: {prompt.model}</Text>
+        {prompt.lora && prompt.lora.length > 0 && <Text>LoRA: {prompt.lora.join(", ")} </Text>}
+        <Text>Sampler: {prompt.sampler}</Text>
+        <Text>CFG Scale: {prompt.cfgScale}</Text>
+        <Text>Steps: {prompt.steps}</Text>
+        <Text>Seed: {prompt.seed}</Text>
+      </Grid>}
+      <Flex pt={5} marginLeft='auto'>
+        {!readonly && <Box>
+          <Button variant='solid' marginRight={2} onClick={(event) => handleOnLoadFromClipboard(event)}>
             {dict["import_from_clipboard"]}
           </Button>
-        </Grid>
-      )}
+          <Button variant='solid' marginRight={2} onClick={(event) => { if (onReset) onReset(event); }}>
+            {dict["reset"]}
+          </Button>
+        </Box>}
+        <Button variant='solid' colorScheme='teal'>
+          <CopyComponent value={StableDiffusionDataToString(prompt)} />
+        </Button>
+      </Flex>
     </Grid>
   );
 }


### PR DESCRIPTION
- Use workaround to fix negative prompt not working for hugging face api
- Add colon to prompt weight
- Make sd generator ui responsive
- Switch `stable diffusion-v2.1-base` to more well known `v1.5`
- Switch `anything-v4.0` to `Counterfeit-V2.5` to get less chance of getting blocked results
- Implement `wait_for_model` when rated limited based on [official js client](https://github.com/huggingface/huggingface.js).